### PR TITLE
Rack 3 compatibility

### DIFF
--- a/lib/rack/indifferent.rb
+++ b/lib/rack/indifferent.rb
@@ -9,7 +9,7 @@ if Rack.release > '2'
         return make_params.to_params_hash if qs.nil? || qs.empty?
         super
       end
-      
+
       class Params < Rack::QueryParser::Params
         INDIFFERENT_PROC = lambda{|h,k| h[k.to_s] if k.is_a?(Symbol)}
 
@@ -20,7 +20,11 @@ if Rack.release > '2'
         end
       end
 
-      Rack::Utils.default_query_parser = new(Params, 65536, 100)
+      if Rack::VERSION[0].to_i < 3
+        Rack::Utils.default_query_parser = new(Params, 65536, 100)
+      else
+        Rack::Utils.default_query_parser = new(Params, 65536)
+       end
     end
   end
 else


### PR DESCRIPTION
Was attempting to utilize this lib with Rack 3 and received the following error:
```
/Users/batkins/.rvm/gems/ruby-3.4.6@roda/gems/rack-3.2.1/lib/rack/query_parser.rb:60:in 'initialize': wrong number of arguments (given 3, expected 2) (ArgumentError)
	from /Users/batkins/.rvm/gems/ruby-3.4.6@roda/gems/rack-indifferent-1.2.0/lib/rack/indifferent.rb:23:in 'Class#new'
	from /Users/batkins/.rvm/gems/ruby-3.4.6@roda/gems/rack-indifferent-1.2.0/lib/rack/indifferent.rb:23:in '<class:QueryParser>'
	from /Users/batkins/.rvm/gems/ruby-3.4.6@roda/gems/rack-indifferent-1.2.0/lib/rack/indifferent.rb:6:in '<module:Indifferent>'
	from /Users/batkins/.rvm/gems/ruby-3.4.6@roda/gems/rack-indifferent-1.2.0/lib/rack/indifferent.rb:5:in '<top (required)>'
...
```

This parses the rack version and adjusts the number of args passed to the query parser depending on which version of Rack is required